### PR TITLE
Fast fix oop_getFieldBaseValue (2)

### DIFF
--- a/Src/Editor/GameObjectsAssembly/GOAsm_oop_preinit.sqf
+++ b/Src/Editor/GameObjectsAssembly/GOAsm_oop_preinit.sqf
@@ -164,7 +164,7 @@ oop_getFieldBaseValue = {
 	if (_doCompile) then {
 		private _val = call compile _valStr;
 		if (isNullVar(_val) && {not_equals(_altMethodNameIfNil,"")}) then {
-			_val = nil call (_type getVariable [_altMethodNameIfNil,{"ERROR_RUNTIME_METHOD_GET_VALUE"}])
+			_val = locationNull call (_type getVariable [_altMethodNameIfNil,{"ERROR_RUNTIME_METHOD_GET_VALUE"}])
 		};
 
 		_valStr = _val;


### PR DESCRIPTION
При передаче null в агрументы команды call она пропускается. Обходным решением стало изменение параметра с null на nullPtr