### PR TITLE
Минорные исправления серверной части

### DIFF
--- a/Src/Editor/Core/Core_fileWatcher.sqf
+++ b/Src/Editor/Core/Core_fileWatcher.sqf
@@ -15,6 +15,7 @@ variable_define
 	fileWatcher_list_ignoredPathParts = [
 		"\GameModes\scripted_loader.hpp",
 		"\Src\host\ReNode\compile\script_list.hpp",
+		"\Src\Editor\Bin\Maps",
 		".txt"
 	];
 

--- a/Src/Editor/GameObjectsAssembly/GOAsm_oop_preinit.sqf
+++ b/Src/Editor/GameObjectsAssembly/GOAsm_oop_preinit.sqf
@@ -95,6 +95,7 @@ oop_getSimpleTypeSize = {
 */
 
 // object istypeof gameobject (from base to childs) (!!!Slower)
+//TODO replace by oop_isTypeOfBase
 oop_isTypeOf = {
 	params ["_searched","_type"];
 	if (_type == _searched) exitwith {true};
@@ -105,6 +106,13 @@ oop_isTypeOf = {
 		if (_x == _searched) exitwith {_findedClass = true};
 	} foreach _list;
 	_findedClass
+};
+
+// дочерний является подтипом родительского item istypeofbase gameobject, torch istypeofbase item
+oop_isTypeOfBase = {
+	params ["_class","_base"];
+	if (_class == _base) exitwith {true};
+	(tolower _base) in ([_class,"__inhlist_map"] call oop_getTypeValue)
 };
 
 oop_isImplementClass = {

--- a/Src/Editor/SystemTools/PerformanceObjectsTest.sqf
+++ b/Src/Editor/SystemTools/PerformanceObjectsTest.sqf
@@ -11,10 +11,17 @@ init_function(pertest_init)
 	pertest_handle_renderingChunks = -1;
 
 	pertest_optimalObjectCount = createHashMap; //оптимальное количество объектов
-	pertest_optimalObjectCount set [chunkType_item,		40];
-	pertest_optimalObjectCount set [chunkType_structure,60];
-	pertest_optimalObjectCount set [chunkType_decor,	80];
+	pertest_optimalObjectCount set [chunkType_item,		80];
+	pertest_optimalObjectCount set [chunkType_structure,100];
+	pertest_optimalObjectCount set [chunkType_decor,	150];
 	
+	pertest_handle_perfChunk = -1;
+	pertest_perfChunk_lastUpdate = 0;
+	pertest_perfChunk_updateDelay = 1.5;
+	pertest_perfChunk_objList = [];
+
+	pertest_perfChunk_cachedRender = [];
+
 	//imports:
 	/*
 		noe_posToChunk
@@ -22,6 +29,16 @@ init_function(pertest_init)
 		noe_collectAroundChunks
 	*/
 	#include "..\..\host\NOEngine\NOEngine_Shared.sqf"	
+}
+
+function(pertest_chunkPerformanceToggle)
+{
+	if (pertest_handle_perfChunk == -1) then {
+		pertest_handle_perfChunk = ["onFrame",pertest_perfChunkOnUpdate] call Core_addEventHandler;
+	} else {
+		["onFrame",pertest_handle_perfChunk] call Core_removeEventHandler;
+		pertest_handle_perfChunk = -1;
+	};
 }
 
 function(pertest_chunkViewToggle)
@@ -85,7 +102,7 @@ function(pertest_drawChunkSquad)
 	//TODO cast ray front to camera (center postion) and get Z value
 	([(positionCameraToWorld [0,0,0])vectoradd[0,0,-10000]] call golib_om_getRayCastData) params ["","_itPos"];
 	if equals(_itPos,vec3(0,0,0)) then {
-		_itPos = getPosATL cameraOn;
+		_itPos = getPosATL get3DENCamera;
 	};
 	_basicPos set [2,(_itPos select 2) + 0.15];
 	_linePos = +_basicPos;
@@ -115,6 +132,142 @@ function(pertest_drawChunkSquad)
 	drawLine3D [_linePos vectorAdd [0,_size,0],_linePos vectorAdd [0,_size,_upside],_color];
 	drawLine3D [_linePos vectorAdd [_size,_size,0],_linePos vectorAdd [_size,_size,_upside],_color];
 	
+}
+
+function(pertest_perfChunkOnUpdate)
+{
+	if (tickTime > pertest_perfChunk_lastUpdate) then {
+		call pertest_perfChunk_collectObjects;
+		pertest_perfChunk_lastUpdate = tickTime + pertest_perfChunk_updateDelay;
+		pertest_perfChunk_cachedRender = []; //cache cleanup
+	};
+	//draw info
+	_chunkTypes = [chunkType_item,chunkType_structure,chunkType_decor];
+	_curDrawedChunks_ALL = [createHashMap,createHashMap,createHashMap];
+	
+	_curDrawedChunks = null;
+	_curChType = -1;
+
+	_myPos = getPosATL get3DENCamera;
+	{
+		_curChType = _chunkTypes select _foreachIndex;
+		_curDrawedChunks = _curDrawedChunks_ALL select _foreachIndex;
+		_myChunkPos = [_myPos,_curChType] call noe_posToChunk;
+		
+		{
+			_ch = [getPosAtl _x,_curChType] call noe_posToChunk;
+			//if (_ch distance _myChunkPos > 2) then {continue};
+
+			_chStr = str _ch;
+			
+			if (_chStr in _curDrawedChunks) then {
+				_cdcObj = (_curDrawedChunks get _chStr);
+				_cdcObj set [1,(_cdcObj select 1) + 1];
+			} else {
+				_curDrawedChunks set [_chStr,[
+					[_ch,_curChType] call noe_chunkToPos,
+					1,
+					_ch
+				]]
+			};
+		} foreach _x; //_x is objectList
+	} foreach pertest_perfChunk_objList;
+
+	([(positionCameraToWorld [0,0,0])vectoradd[0,0,-10000]] call golib_om_getRayCastData) params ["","_itPos"];
+	if equals(_itPos,vec3(0,0,0)) then {
+		_itPos = getPosATL get3DENCamera;
+	};
+
+	//["Draw chunks %1",_curDrawedChunks_ALL apply {count _x}] call printTrace;
+	if (count pertest_perfChunk_cachedRender > 0) exitWith {
+		{
+			drawIcon3D _x;
+		} foreach pertest_perfChunk_cachedRender;
+	};
+
+
+	_zPos = _itPos select 2;
+	{
+		_curChType = _chunkTypes select _foreachIndex;
+		
+		_chName = ["Item","Struct","Decor"] select _foreachIndex;
+		
+		
+		{
+			_y params ["_basicPos","_count","_chunk"];
+
+			//["draw %1 = %2 %3",_chName,_basicPos,_count] call printTrace;
+
+			_size = getChunkSizeByType(_curChType);
+			MODARR(_basicPos,0,+ _size / 2);
+			MODARR(_basicPos,1,+ _size / 2);
+
+			if ((_basicPos select [0,2]) distance (_myPos select [0,2]) > _size * 2) then {continue};
+
+
+			_maxCount = pertest_optimalObjectCount get _curChType;
+			_color = [0,1,0,1];
+			_budgetText = "";
+			_textSize = 0.05;
+			if (_count > _maxCount) then {
+				_budgetText = format["Бюджет превышен на %1 объектов (загружено %2%3)",_count - _maxCount,(_count*100/_maxCount),"%"];
+				_color = [1,0,0,1];
+				_textSize = 0.07;
+			} else {
+				_budgetText = "Оптимально";
+				_colAdd = linearConversion [precentage(_maxCount,70),_maxCount,_count,0,1,true];
+				_color set [0,_colAdd];
+				if (_colAdd > 0) then {
+					_budgetText = "Приемлемо"
+				};
+				if (_colAdd > 0.5) then {_budgetText = "Допустимо"};
+				_budgetText = format["%1 (%2%3)",_budgetText,(_count*100/_maxCount),"%"];
+			};
+
+			_tRender = format ["%4:%2 = %1; %3",
+				_count,
+				_chName,
+				_budgetText,
+				_chunk
+			];
+			_basicPos set [2,_zPos+0.2+(_forEachIndex * 0.1)];
+			pertest_perfChunk_cachedRender pushBack ["", _color, _basicPos, 0.5, 0.5, 0,_tRender,1, _textSize, "TahomaB"];
+			//drawIcon3D ["", _color, _basicPos, 0.5, 0.5, 0,_tRender,1, _textSize, "TahomaB"];
+
+		} foreach _x;
+	} foreach _curDrawedChunks_ALL;
+}
+
+function(pertest_perfChunk_collectObjects)
+{
+	_basePos = getPosATL get3DENCamera;
+	_collectDist = (chunkSize_decor *1.5)*2;
+	//_collectDist = coldist;
+	_campos = _basePos;
+	_objList = (_campos select [0,2]) nearObjects _collectDist; //nearestObjects [_campos,[],_collectDist,true];
+	
+	_class = null;
+	_curObj = null;
+	_typeassoc = ["Item","IStruct","Decor"];
+	
+	//хранилище объектов по типам чанков
+	_objChunks = [];
+	_objChunks resize (count _typeassoc);
+	_objChunks = _objChunks apply {[]};
+	
+	{
+		_curObj = _x;
+		_class = [_curObj] call golib_getClassName;
+		if !isNullVar(_class) then {
+			{
+				if ([_class,_x] call oop_isTypeOfBase) exitWith {
+					(_objChunks select _foreachIndex) pushBack _curObj;
+				};
+			} foreach _typeassoc;
+		};
+	} foreach _objList;
+
+	pertest_perfChunk_objList = _objChunks;
 }
 
 

--- a/Src/Editor/SystemTools/PerformanceObjectsTest.sqf
+++ b/Src/Editor/SystemTools/PerformanceObjectsTest.sqf
@@ -42,11 +42,18 @@ function(pertest_showRenderingChunks)
 function(pertest_showRendeing_onUpdate)
 {
 		_colorSide = [0,0,0,1];
+		_allColors = [
+			[((["Item","Class","ColorClass"] call goasm_attributes_getValues) select 0)] call color_HTMLtoRGBA,
+			[((["IStruct","Class","ColorClass"] call goasm_attributes_getValues) select 0)] call color_HTMLtoRGBA,
+			[((["Decor","Class","ColorClass"] call goasm_attributes_getValues) select 0)] call color_HTMLtoRGBA
+		];
+		
+
 		{
 			_chunk = [getPosATL get3DENCamera, _x] call noe_posToChunk;
 			_pos = [_chunk,_x] call noe_chunkToPos;
 
-			_colorSide set [_forEachIndex,1];
+			_colorSide = _allColors select _foreachIndex;
 
 			[_chunk,_x,_colorSide] call pertest_drawChunkSquad;
 
@@ -95,6 +102,7 @@ function(pertest_drawChunkSquad)
 	];
 	_basicPos set [2,(_basicPos select 2)+(_forEachIndex * 0.1)];
 	drawIcon3D ["", _color, _basicPos, 0.5, 0.5, 0,_tRender,1, 0.03, "TahomaB"];
+	_upside = _size;
 
 	drawLine3D [_linePos,_linePos vectorAdd [_size,0,0],_color];
 	drawLine3D [_linePos,_linePos vectorAdd [0,_size,0],_color];
@@ -102,10 +110,10 @@ function(pertest_drawChunkSquad)
 	drawLine3D [_linePos vectorAdd [_size,_size,0],_linePos vectorAdd [0,_size,0],_color];
 	//to up
 	
-	drawLine3D [_linePos vectorAdd [0,0,0],_linePos vectorAdd [0,0,upside],_color];
-	drawLine3D [_linePos vectorAdd [_size,0,0],_linePos vectorAdd [_size,0,upside],_color];
-	drawLine3D [_linePos vectorAdd [0,_size,0],_linePos vectorAdd [0,_size,upside],_color];
-	drawLine3D [_linePos vectorAdd [_size,_size,0],_linePos vectorAdd [_size,_size,upside],_color];
+	drawLine3D [_linePos vectorAdd [0,0,0],_linePos vectorAdd [0,0,_upside],_color];
+	drawLine3D [_linePos vectorAdd [_size,0,0],_linePos vectorAdd [_size,0,_upside],_color];
+	drawLine3D [_linePos vectorAdd [0,_size,0],_linePos vectorAdd [0,_size,_upside],_color];
+	drawLine3D [_linePos vectorAdd [_size,_size,0],_linePos vectorAdd [_size,_size,_upside],_color];
 	
 }
 

--- a/Src/Editor/VisualComponents/RelativePositionEditor.sqf
+++ b/Src/Editor/VisualComponents/RelativePositionEditor.sqf
@@ -15,7 +15,7 @@ init_function(vcom_relpos_initialize)
 	vcom_relpos_dataVar = createHashMap;
 
 	//насколько каждая точка может быть от начала координат (для любой оси)
-	vcom_relpos_maxPointDistance = 10;
+	vcom_relpos_maxPointDistance = 50;
 	vcom_relpos_sliderPosChangeDelta = 0.001;
 }
 

--- a/Src/Editor/VisualComponents/ScriptedEmitterEditor.sqf
+++ b/Src/Editor/VisualComponents/ScriptedEmitterEditor.sqf
@@ -52,7 +52,7 @@ init_function(vcom_emit_initialize)
 	vcom_emit_widgets = [widgetNull,widgetNull];
 
 	//насколько каждая точка может быть от начала координат (для любой оси)
-	vcom_emit_maxPointDistance = 10;
+	vcom_emit_maxPointDistance = 50;
 	vcom_emit_sliderPosChangeDelta = 0.001;
 
 	vcom_emit_emitterTypeAssoc = createHashMapFromArray [

--- a/Src/Editor/Widgets/Widget_ContextMenu.sqf
+++ b/Src/Editor/Widgets/Widget_ContextMenu.sqf
@@ -580,8 +580,8 @@ init_function(ContextMenu_mouseArea_init)
 				};
 			} else {
 				//all not null
-				_d1 = _obj distance cameraOn;
-				_d2 = _mobj distance cameraOn;
+				_d1 = _obj distance get3DENCamera;
+				_d2 = _mobj distance get3DENCamera;
 				if (_d1 < _d2) then {
 					_obj = _obj;
 				} else {

--- a/Src/Editor/Widgets/Widget_init.sqf
+++ b/Src/Editor/Widgets/Widget_init.sqf
@@ -155,7 +155,8 @@ menu_structureLayout = [
 			"text:Проверка несуществующих конфигов света на карте;act:call lightValidator_process",
 			"text:Проверка путей классов;act:call systools_checkClassPathes",
 			"text:Проверка классов с одинаковыми моделями;act:call classValidator_validateModels",
-			"text:Проверка нагрузки сцены игровыми объектами;act:['Не реализовано'] call showWarning;"
+			"",
+			"text:Проверка нагрузки сцены игровыми объектами;act:call pertest_chunkPerformanceToggle;"
 		],
 		"",
 		"text:Редактор ReNode;act:call vs_openEditor",

--- a/Src/client/NOEngineClient/NOEngineClientInit.sqf
+++ b/Src/client/NOEngineClient/NOEngineClientInit.sqf
@@ -90,7 +90,7 @@ noe_client_unloadAllChunks = {
 		_chunkList = [];
 		_chunkType = _x;
 		_chunk = [getPosATL _mob,_chunkType] call noe_posToChunk;
-		[_mob,_chunkList,_chunk,_chunkType] call noe_collectAroundChunks;
+		[_chunkList,_chunk,_chunkType] call noe_collectAroundChunks;
 		
 		//выгружаем
 		{

--- a/Src/client/NOEngineClient/NOEngineClient_onUpdate.sqf
+++ b/Src/client/NOEngineClient/NOEngineClient_onUpdate.sqf
@@ -22,8 +22,8 @@ private _chunksToUnload = [];
 _chunk = [getPosATL _mob,_chunkType] call noe_posToChunk;
 _prevChunk = _mob getVariable [variable_name_prevchunk + str _chunkType,_chunk];
 
-[_mob,_chunksToLoad,_chunk,_chunkType] call noe_collectAroundChunks;
-[_mob,_chunksToUnload,_prevChunk,_chunkType] call noe_collectAroundChunks;
+[_chunksToLoad,_chunk,_chunkType] call noe_collectAroundChunks;
+[_chunksToUnload,_prevChunk,_chunkType] call noe_collectAroundChunks;
 
 _mob setvariable [variable_name_prevchunk + str _chunkType,_chunk];
 

--- a/Src/host/Client/client.sqf
+++ b/Src/host/Client/client.sqf
@@ -154,6 +154,9 @@ class(ServerClient) /*extends(NetObject)*/
 
 		//удаляем из претендентов
 		if getSelf(isReady) then {
+			
+			setSelf(isReady,false);
+			
 			if (call gm_isRoundLobby) then {
 				/*_setList = getSelf(charSettingsValues);
 
@@ -178,8 +181,6 @@ class(ServerClient) /*extends(NetObject)*/
 				};*/
 				callSelf(removeDefaultRoles); //Функционал убирания игрока из претендентов
 			};
-
-			setSelf(isReady,false);
 
 		};
 		if getSelf(isInEmbark) then {
@@ -714,7 +715,7 @@ class(ServerClient) /*extends(NetObject)*/
 				} else {
 
 					private _oldContenders =  getVarReflect(_oldData,"contenders_"+str (_forEachIndex+1));
-					private _oldClientIndex = _oldContenders findif {equals(_x,_client)};
+					private _oldClientIndex = _oldContenders findif {equals(_x,this)};
 					if (_oldClientIndex == -1) then {
 						warningformat("ServerClient::removeDefaultRoles() - Cant find client for remove in role %1",_role);
 					} else {

--- a/Src/host/GameObjects/Mobs/Mob_Interact.sqf
+++ b/Src/host/GameObjects/Mobs/Mob_Interact.sqf
@@ -1164,6 +1164,7 @@ region(stealing handler)
 		if equals(_targ,this) exitWith {
 			callSelfParams(localSay,"У себя не украсть." arg "error");
 		};
+		if !callFunc(_targ,isMob) exitwith {};
 		if !callSelf(isEmptyActiveHand) exitWith {
 			callSelfParams(localSay,"Руку надо освободить." arg "error");
 		};

--- a/Src/host/Logger/Logger_init.sqf
+++ b/Src/host/Logger/Logger_init.sqf
@@ -48,6 +48,7 @@ logger_internal_map = hashMapNew;
 })
 
 #define __log_prefix(typo) '(typo)	'
+#define __log_prefix_DEBUG "(DEBUG)	"
 
 #define isImplementedLoggerFunction(cat) !isNull( missionNamespace getvariable vec2(cat + "log",nil))
 
@@ -121,7 +122,7 @@ logger_internal_registerLogCategory = {
 	};
 	logDebug = {
 		#ifdef DEBUG
-		[__log_prefix(DEBUG) + format _this,"system","debug"] call systemLog;
+		[__log_prefix_DEBUG + format _this,"system","debug"] call systemLog;
 		#endif
 	};
 	logTrace = {

--- a/Src/host/NOEngine/NOEngineInit.sqf
+++ b/Src/host/NOEngine/NOEngineInit.sqf
@@ -50,8 +50,8 @@ noe_onMainThread = {
 	_chunk = [getPosATL _mob,_chunkType] call noe_posToChunk;
 	_prevChunk = _mob getVariable [variable_name_prevchunk + str _chunkType,_chunk];
 
-	[_mob,_chunksToLoad,_chunk,_chunkType] call noe_collectAroundChunks;
-	[_mob,_chunksToUnload,_prevChunk,_chunkType] call noe_collectAroundChunks;
+	[_chunksToLoad,_chunk,_chunkType] call noe_collectAroundChunks;
+	[_chunksToUnload,_prevChunk,_chunkType] call noe_collectAroundChunks;
 
 	_mob setvariable [variable_name_prevchunk + str _chunkType,_chunk];
 
@@ -80,8 +80,8 @@ noe_onMainThread = {
 		_chunk = [getPosATL _x,_chunkType] call noe_posToChunk;
 		_prevChunk = _x getVariable ["prevChunk" + str _chunkType,_chunk];
 
-		[_x,_chunksToLoad,_chunk,_chunkType] call noe_collectAroundChunks;
-		[_x,_chunksToUnload,_prevChunk,_chunkType] call noe_collectAroundChunks;
+		[_chunksToLoad,_chunk,_chunkType] call noe_collectAroundChunks;
+		[_chunksToUnload,_prevChunk,_chunkType] call noe_collectAroundChunks;
 
 		_x setvariable ["prevChunk" + str _chunkType,_chunk];
 	} foreach cm_allInGameMobs;

--- a/Src/host/NOEngine/NOEngine_Shared.sqf
+++ b/Src/host/NOEngine/NOEngine_Shared.sqf
@@ -30,11 +30,9 @@ noe_chunkToPos = {
 
 
 noe_collectAroundChunks = {
-	params ["_mobClient","_loadList","_chunk","_chunkType"];
+	params ["_loadList","_chunk","_chunkType"];
 
 	_loadList pushBackUnique [_chunk,_chunkType];
-
-	//if (!isPlayer _mobClient) exitWith {};
 
 	{
 		_loadList pushBackUnique [(_chunk vectorAdd _x) select [0,2],_chunkType];


### PR DESCRIPTION
# Описание
Общие исправления редактора и сервера. Так же реализован проверщик загруженности карты игровыми объектами

## Валидатор сцены
Запускается из вкладки `Инструменты`. Выключается повторным нажатием по этому пункту меню.
![image](https://github.com/Relicta-Team/ReSDK_A3.vr/assets/35444748/dee61e13-581f-4a77-865f-35cfe0d5381b)
Пример вывода в сцене. Чанки, загруженность которых выше 100% необходимо оптимизировать.
![Безымянный](https://github.com/Relicta-Team/ReSDK_A3.vr/assets/35444748/7fdaf74a-a898-4f02-b68b-6737470b0400)

# Изменения
- Добавлен валидатор загруженности сцены
- Фикс #274
- Фикс #262 
- Фикс #287 
- Фикс #263 
- Фикс #277 
- Исправлен старт режима когда на слоте стоит отключенный игрок