### PR TITLE
Симуляция частиц и освещения в редакторе

### DIFF
--- a/Src/Editor/Core/Core_fileWatcher.sqf
+++ b/Src/Editor/Core/Core_fileWatcher.sqf
@@ -54,6 +54,7 @@ function(fileWatcher_guardSafeRebuild)
 function(fileWatcher_onFrame)
 {
 	if (!isGameFocused) exitwith {};
+	if (call isDisplayOpened) exitWith {};
 
 	if (tickTime >= fileWatcher_internal_lastTickTime) then {
 		fileWatcher_internal_lastTickTime = tickTime + fileWatcher_internal_const_updateDelay;

--- a/Src/Editor/Core/Core_postInit.sqf
+++ b/Src/Editor/Core/Core_postInit.sqf
@@ -105,6 +105,9 @@ projectEditor_isCompileProcess = false;
 
 if (Core_catchedInitError) exitWith {};
 
+//init object creation event
+call Core_initObjects;
+
 //main loader gameobjects
 _postInit = {
 	call core_settings_init;

--- a/Src/Editor/GameObjectsAssembly/GOAsm_providers.sqf
+++ b/Src/Editor/GameObjectsAssembly/GOAsm_providers.sqf
@@ -524,6 +524,23 @@ function(goasm_attributes_handleProvider_scriptedlight)
 			};
 		};
 	} call _setSyncValCode;
+	_input ctrlSetTooltip "ПКМ - для открытия редактирования этого конфига";
+	{
+		if (_key == MOUSE_RIGHT) then {
+			_postcode = {
+				params ["_obj","_text"];
+				if isNullVar(_text) exitWith {};
+				if equals(_text,"") exitWith {};
+				if ("deprecated" in _text) exitWith {};
+
+				_obj call vcom_emit_createVisualWindow;
+				
+				[_text] call vcom_emit_io_loadConfigCheck;
+			};
+			nextFrameParams(_postcode,[_objWorld arg ctrlText _wid]);
+		};
+	} call _setOnPressCode;
+
 	[BUTTON,[10,_optimalSizeH],_offsetMemX + 40,true] call _createElement;
 	_wid ctrlSetText "+";
 	_wid ctrlSetTooltip "ЛКМ - меню выбора света\nПКМ - сброс на стандартное значение";
@@ -565,6 +582,9 @@ function(goasm_attributes_handleProvider_scriptedlight)
 							};
 							[_objWorld,_data,true] call golib_setHashData;
 							call (_wid getVariable "_onSync");	
+
+							[_objWorld] call lsim_reloadLightOnObject;
+
 						} call Core_callContext;
 						call Core_popContext;
 					},
@@ -587,6 +607,7 @@ function(goasm_attributes_handleProvider_scriptedlight)
 			[_objWorld,_data,true] call golib_setHashData;
 			call (_wid getVariable "_onSync");
 			
+			[_objWorld] call lsim_reloadLightOnObject;
 		};
 	} call _setOnPressCode;
 }

--- a/Src/Editor/GameObjectsLibrary/GOLib_hashData.sqf
+++ b/Src/Editor/GameObjectsLibrary/GOLib_hashData.sqf
@@ -429,6 +429,8 @@ function(golib_internal_handleVersionUpdate)
 		   	//add object to layer
 			[_objNew,"Effects"] call layer_addObject;
 
+			[_objNew,true] call Core_initObjectEvents;
+
 			["Updated object %1",_objNew] call printLog;
 		};
 		if (typeof _obj == "Land_VR_Block_02_F" && _hasHashData) exitWith {

--- a/Src/Editor/GameObjectsLibrary/GOLib_objectManager.sqf
+++ b/Src/Editor/GameObjectsLibrary/GOLib_objectManager.sqf
@@ -115,7 +115,7 @@ function(golib_om_placeObjectAtMouse)
 		[_obj,_gameObject] call golib_initHashData;
 		
 		[_obj] call golib_om_internal_handleTransformEvent;
-		
+		[_obj,true] call Core_initObjectEvents;
 		if (_flagEffect) then {
 			[_obj,_gameObject] call goasm_iapi_effect_preparModel;
 		};
@@ -389,6 +389,7 @@ function(golib_om_replaceObject)
 			[_obj,_rot] call golib_om_setRotation;
 			
 			[_obj] call golib_om_internal_handleTransformEvent;
+			[_obj,true] call Core_initObjectEvents;
 			
 			call golib_cs_syncMarks;
 

--- a/Src/Editor/SystemTools/LigthSimulation.sqf
+++ b/Src/Editor/SystemTools/LigthSimulation.sqf
@@ -1,0 +1,283 @@
+// ======================================================
+// Copyright (c) 2017-2024 the ReSDK_A3 project
+// sdk.relicta.ru
+// ======================================================
+
+init_function(lsim_init)
+{
+	//first - unload all lights (if catched error on runtime)
+	if (!isNull(lsim_objMap)) then {
+		{
+			_x switchLight "off";
+			_x enableSimulation false;
+		} foreach (values lsim_objMap);
+	};
+	if (!isNull(lsim_internal_registeredLights)) then {
+		{
+			{
+				detach _x;
+				deleteVehicle _x;
+			} foreach _y;
+		} foreach lsim_internal_registeredLights;
+	};
+
+
+	lsim_mode = false; //false - off, true - on
+	lsim_objMap = createHashMap;
+	lsim_internal_registeredLights = createHashMap;
+
+	le_allLights = [];
+
+	lsim_internal_handleUndo = -1;
+	lsim_internal_handleRedo = -1;
+
+
+	["onObjectAdded",lsim_internal_event_onAdded] call Core_addEventHandler;
+	["onObjectRemoved",lsim_internal_event_onRemoved] call Core_addEventHandler;
+
+}
+
+function(lsim_internal_event_onAdded)
+{
+	params ["_obj"];
+	if (lsim_mode) then {
+		if (_obj call lsim_canSimulateLight) then {
+			[_obj] call lsim_internal_loadLight;
+		};
+	};
+}
+
+function(lsim_internal_event_onRemoved)
+{
+	params ["_obj"];
+	if (lsim_mode) then {
+		if (_obj call lsim_isLightSimulated) then {
+			[_obj] call lsim_internal_unloadLight;
+		};
+	}
+}
+
+function(lsim_isLightSimulated) { params ["_obj"];(hashValue _obj) in lsim_objMap }
+function(lsim_canSimulateLight) { 
+	params ["_obj"];
+	private _v = [_obj,"light"] call golib_getActualDataValue;
+	if equalTypes(_v,0) exitWith {
+		inRange(_v,le_se_cfgRange select 0,le_se_cfgRange select 1)	
+	};
+	not_equals(_v,"")
+}
+function(lsim_allLightObjects) { values lsim_objMap }
+
+function(lsim_resolveObjectConfig)
+{
+	params ["_obj"];
+
+	if !(call vcom_emit_io_isConfigsLoaded) then {
+		call vcom_emit_io_readConfigs;
+	};
+
+	//use: vcom_emit_io_enumAssocKeyStr, vcom_emit_io_enumAssocKeyInt
+	if !(call vcom_emit_io_isEnumConfigsLoaded) then {
+		[true] call vcom_emit_io_loadEnumAssoc;
+	};
+
+	private _lt = [_obj,"light"] call golib_getActualDataValue;
+	if equalTypes(_lt,0) then {
+		_lt = str _lt;
+	};
+	
+	//is numeric
+	private _cfg = vcom_emit_io_enumAssocKeyInt get _lt;
+	if isNullVar(_cfg) then {
+		_cfg = vcom_emit_io_enumAssocKeyStr get _lt;
+		if isNullVar(_cfg) exitWith {""};
+		if !inRange(parseNumber _cfg,le_se_cfgRange select 0,le_se_cfgRange select 1) then {
+			""
+		} else {
+			[_lt,""] call vcom_emit_io_parseConfigName;
+		}
+	} else {
+		if !inRange(parseNumber _lt,le_se_cfgRange select 0,le_se_cfgRange select 1) then {
+			""
+		} else {
+			[_lt,""] call vcom_emit_io_parseConfigName;
+		};
+	};
+	
+}
+
+function(lsim_internal_buildScriptedConfigs)
+{
+	call compile preprocessFileLineNumbers "Src\Editor\SystemTools\LigthSimulation_cfgLoader.sqf"
+}
+
+function(lsim_setMode)
+{
+	params ["_mode"];
+	if (_mode == lsim_mode) exitWith {};
+
+	//set night
+	if ((call rendering_isNightEnabled) != _mode) then {
+		_mode call rendering_setNight;
+	};
+
+	if (_mode) then {
+		//preinit internal data
+		call lsim_internal_buildScriptedConfigs;
+		
+		//collect objects
+		{
+			[_x] call lsim_internal_loadLight;
+		} foreach (call lsim_internal_collectLightObjects);
+
+		lsim_internal_handleUndo = ["onUndo",{call lsim_internal_rebuildAllLights}] call Core_addEventHandler;
+		lsim_internal_handleRedo = ["onRedo",{call lsim_internal_rebuildAllLights}] call Core_addEventHandler;
+		
+	} else {
+
+		["onUndo",lsim_internal_handleUndo] call Core_removeEventHandler;
+		["onRedo",lsim_internal_handleRedo] call Core_removeEventHandler;
+		lsim_internal_handleUndo = -1;
+		lsim_internal_handleRedo = -1;
+
+		{
+			[_x] call lsim_internal_unloadLight;
+		} foreach (call lsim_allLightObjects);
+
+		if (count (call lsim_allLightObjects) > 0) then {
+			setLastError("Light objects still exists on unloading...");
+		};
+	};
+
+	lsim_mode = _mode;
+}
+
+function(lsim_internal_collectLightObjects)
+{
+	private _olist = [];
+	{
+		if (_x call golib_hasHashData && {not_equals(golib_com_object,_x)}) then {
+			private _hash = [_x,true] call golib_getHashData;
+			private _class = _hash get "class";
+			_lt = [_class,"light"] call oop_getFieldBaseValue;
+			if (_lt != "") then {
+				_olist pushBack _x;
+			};
+		};
+	} foreach (all3DENEntities select 0);
+
+	_olist
+}
+
+function(lsim_internal_rebuildAllLights)
+{
+	{
+		[_x] call lsim_internal_unloadLight;
+	} foreach (call lsim_allLightObjects);
+	{
+		[_x] call lsim_internal_loadLight;
+	} foreach (call lsim_internal_collectLightObjects);
+}
+
+function(lsim_internal_unloadLight)
+{
+	params ["_obj"];
+	
+	["Unloading light from %1",_obj] call printTrace;
+
+	if (simulationEnabled _obj) then {
+		_obj enableSimulation true;
+	};
+
+	lsim_objMap deleteAt (hashValue _obj);
+
+	private _light = _obj getvariable ["__light",objNUll];
+	private _allEmitters = _obj getVariable ["__allEmitters",[]];
+	{
+		deleteVehicle _x;
+	} foreach _allEmitters;
+	_obj setVariable ["__allEmitters",null];
+	_obj setvariable ["__config",null];
+
+	_obj setvariable ["__defBright",null];
+
+	le_allLights deleteat (le_allLights find _light);
+	le_allLights deleteat (le_allLights find _obj);
+
+	lsim_internal_registeredLights deleteAt (hashValue _light);
+
+	deleteVehicle _light;
+}
+
+function(lsim_reloadLightOnObject)
+{
+	params ["_obj"];
+	if (!lsim_mode) exitWith {};
+
+	if (_obj call lsim_canSimulateLight) then { //load with reloading
+		[_obj] call lsim_internal_loadLight;
+	} else {
+		if (_obj call lsim_isLightSimulated) then {
+			[_obj] call lsim_internal_unloadLight;
+		};
+	};
+}
+
+function(lsim_internal_loadLight)
+{
+	params ["_obj"];
+	private _src = _obj;
+	private _canLoad = true;
+
+	private _oldCfg = _src getvariable "__config";
+	if (!isNullVar(_oldCfg)) then {
+		
+		//Вот этот код может вызывать определённые проблемы в некоторых случаях
+		[_src] call lsim_internal_unloadLight;
+		
+	};
+
+	private _ltCfg = [_obj,"light"] call golib_getActualDataValue;
+	
+	//do not load deprecated light config
+	if equalTypes(_ltCfg,0) then {
+		if !inRange(_ltCfg,le_se_cfgRange select 0,le_se_cfgRange select 1) exitWith {
+			_canLoad = false;
+			_ltCfg = "errlt";
+		};
+		//convert config if is set to default value
+		_ltCfg = vcom_emit_io_enumAssocKeyInt getOrDefault [str _ltCfg,"errorlight____"];
+	};
+	
+	if (str parseNumber _ltCfg == _ltCfg || !_canLoad) exitWith {}; //this deprecated light
+
+	private _nullName = "<NULL>";
+	private _parsedName = [_ltCfg,_nullName] call vcom_emit_io_parseConfigName;
+	
+	if (_nullName == _parsedName) exitWith {
+		["Cant load light %1",_ltCfg] call printError;
+	};
+
+	private _cfgLightStr = vcom_emit_io_enumAssocKeyStr get _ltCfg;
+	if isNullVar(_cfgLightStr) exitWith {
+		["Cant load non-existen light %1",_ltCfg] call printError;
+	};
+
+	private _code = missionNamespace getVariable ["le_conf_" + _cfgLightStr,objNull];
+	if equalTypes(_code,objNull) exitWith {
+		["Cant load non-existen light %1 - loader not found",_cfgLightStr] call printError;
+	};
+	
+	["Loading light %1 at %2",_cfgLightStr,_src] call printTrace;
+
+	//enable sim if need
+	if !(simulationEnabled _obj) then {
+		_obj enableSimulation true;
+		_obj switchLight "off";
+	};
+
+	lsim_objMap set [hashValue _obj,_obj];
+
+	private _lt = [_src] call _code;
+	lsim_internal_registeredLights set [hashValue _lt,(_src getvariable "__allEmitters")];
+}

--- a/Src/Editor/SystemTools/LigthSimulation_cfgLoader.sqf
+++ b/Src/Editor/SystemTools/LigthSimulation_cfgLoader.sqf
@@ -1,0 +1,41 @@
+// ======================================================
+// Copyright (c) 2017-2024 the ReSDK_A3 project
+// sdk.relicta.ru
+// ======================================================
+
+#include "..\EditorEngine.h"
+#include "..\..\host\engine.hpp"
+
+if !(call vcom_emit_io_isConfigsLoaded) then {
+	call vcom_emit_io_readConfigs;
+};
+
+//use: vcom_emit_io_enumAssocKeyStr, vcom_emit_io_enumAssocKeyInt
+if !(call vcom_emit_io_isEnumConfigsLoaded) then {
+	[true] call vcom_emit_io_loadEnumAssoc;
+};
+
+//fix 1
+missionNamespace setVariable ["pushFront",
+{
+	params ["_list","_element",["_unique",false]];
+	reverse _list;
+	if (_unique) then {
+		_list pushBackUnique _element;
+	} else {
+		_list pushBack _element;
+	};
+	reverse _list;
+}
+];
+
+//for init varobjects
+
+#include "..\..\client\LightEngine\ScriptedEffects.hpp"
+
+//light functions init
+#include "..\..\client\LightEngine\ScriptedEffects.sqf"
+//configs init
+#include "..\..\client\LightEngine\ScriptedEffectConfigs.sqf"
+
+call le_se_doSorting;

--- a/Src/Editor/SystemTools/SystemTools_init.sqf
+++ b/Src/Editor/SystemTools/SystemTools_init.sqf
@@ -16,3 +16,4 @@
 #include "GeometryCursor.sqf"
 #include "ClassValidator.sqf"
 #include "LightConfigValidator.sqf"
+#include "LigthSimulation.sqf"

--- a/Src/Editor/VisualComponents/ScriptedEmitterEditor.sqf
+++ b/Src/Editor/VisualComponents/ScriptedEmitterEditor.sqf
@@ -100,10 +100,19 @@ function(vcom_emit_closeVisualWindowHandled)
 	call vcom_emit_io_saveAllConfigs;
 
 	call displayClose;
+	false call rendering_setInGameHDR;
+
+	if (lsim_mode) exitWith {
+		// call lsim_internal_buildScriptedConfigs
+		// call lsim_internal_rebuildAllLights;
+		if !(call rendering_isNightEnabled) then {
+			true call rendering_setNight;
+		};
+	};
+
 	if (call rendering_isNightEnabled) then {
 		false call rendering_setNight;
 	};
-	false call rendering_setInGameHDR;
 }
 
 function(vcom_emit_openMainContextMenuSettings)
@@ -238,8 +247,10 @@ function(vcom_emit_createVisualWindow)
 	if (cfg_emed_enableCustomRenderByDefault) then {
 		call vcom_emit_opt_switchRender;
 	};
-	if (cfg_emed_enableNightByDefault) then {
-		call vcom_emit_opt_switchNight;
+	if (!lsim_mode) then {
+		if (cfg_emed_enableNightByDefault) then {
+			call vcom_emit_opt_switchNight;
+		};
 	};
 
 	["Редактор загружен",10] call showInfo;

--- a/Src/Editor/VisualComponents/ScriptedEmitterEditor/ScriptedEmitterEditor_io.sqf
+++ b/Src/Editor/VisualComponents/ScriptedEmitterEditor/ScriptedEmitterEditor_io.sqf
@@ -366,22 +366,34 @@ function(vcom_emit_io_saveAllConfigs)
 
 	//["Запуск процедуры сохранения конфигураций",5] call showInfo;
 	["Start saving config files"] call printLog;
+	
+	vcom_emit_internal_str_cfgNamesContent = _copyright + _indexesOuptut + endl + endl + 
+		"#ifdef SCRIPT_EMIT_EVAL_SERVER" + endl +
+		_postIndexesOutput + endl +
+		"#endif"
+	;
 
 	[vcom_emit_io_configPath,
 		_copyright + _output,null,{
 		["Config saved"] call printLog;
+
+		[vcom_emit_io_configNames,vcom_emit_internal_str_cfgNamesContent
+		,null,{
+			["Config names saved"] call printLog;
+			
+			//reload enums
+			call vcom_emit_io_loadEnumAssoc;
+
+			if (lsim_mode) then {
+				call lsim_internal_buildScriptedConfigs;
+				call lsim_internal_rebuildAllLights;
+			};
+		},{["Cannot save %1",vcom_emit_io_configNames] call printError}] call file_writeAsync;
+
+
 	},{["Cannot save %1",vcom_emit_io_configPath] call printError}] call file_writeAsync;
 
-	[vcom_emit_io_configNames,_copyright + _indexesOuptut + endl + endl + 
-		"#ifdef SCRIPT_EMIT_EVAL_SERVER" + endl +
-		_postIndexesOutput + endl +
-		"#endif"
-	,null,{
-		["Config names saved"] call printLog;
-		
-		//reload enums
-		call vcom_emit_io_loadEnumAssoc;
-	},{["Cannot save %1",vcom_emit_io_configNames] call printError}] call file_writeAsync;
+	
 	
 }
 

--- a/Src/Editor/Widgets/Widget_ContextMenu.sqf
+++ b/Src/Editor/Widgets/Widget_ContextMenu.sqf
@@ -516,7 +516,20 @@ function(ContextMenu_loadMouseObject)
 	_stackMenu pushBack ["<t size='0.9'>Открыть редактор позиций модели</t>",{nextFrameParams(vcom_relposEditorOpen,(call contextMenu_getContextParams) select 0)}];
 	_stackMenu pushBack ["Открыть редактор эмиттеров",{
 		private _obj = (call contextMenu_getContextParams) select 0;
-		nextFrameParams(vcom_emit_createVisualWindow,_obj);
+		private _params = [_obj];
+		private _cfg = [_obj] call lsim_resolveObjectConfig;
+		if (_cfg != "") then {
+			_params pushBack _cfg;
+		};
+		private _code = {
+			params ["_obj",["_cfg",""]];
+			[_obj] call vcom_emit_createVisualWindow;
+			
+			if (_cfg != "") then {
+				[_cfg] call vcom_emit_io_loadConfigCheck;
+			};
+		};
+		nextFrameParams(_code,_params);
 	}];
 
 	// _stackMenu pushBack ["Добавить комментарий",{

--- a/Src/Editor/Widgets/Widget_init.sqf
+++ b/Src/Editor/Widgets/Widget_init.sqf
@@ -187,7 +187,7 @@ menu_structureLayout = [
 		"text:Запуск симуляции с последним режимом и ролью;act:call sim_startSimFromCache",
 		"text:Настроить симуляцию и запустить;act:call sim_openDetaliSetup",
 		"",
-		"text:Запуск симуляции частиц;act:['Не реализовано. Тут можно будет прямо в редакторе посмотреть как выглядит карта ночью с частицами']call showWarning"
+		"text:Запуск/остановка симуляции частиц и освещения;act:[!lsim_mode] call lsim_setMode"
 	],
 	["text:Информация",
 		"text:Версия редактора "+str Core_version_name + ";ena:false",


### PR DESCRIPTION
# Описание
С этой версией появилась возможность предпросмотра освещения и частиц в режиме редактора.
Для запуска перейдите в меню `Запуск`
![sim_start](https://github.com/Relicta-Team/ReSDK_A3.vr/assets/35444748/d9883c14-d04b-424f-b241-07420e85bfe8)

Так же в новой версии вы можете открыть текущий конфиг частиц, установленный на игровом объекте. Это полезная фича, которая избавляет вас от постоянной загрузки конфигов при открытии редактора частиц. 
![emit_opn1](https://github.com/Relicta-Team/ReSDK_A3.vr/assets/35444748/2a026bfc-82b5-46e3-902d-7c075300ef49)
![emit_opn2](https://github.com/Relicta-Team/ReSDK_A3.vr/assets/35444748/4aeac9d0-bc43-47f8-b729-e619c891cd96)

## Примечания
- Если на объекте нет освещения, либо используется конфиг из старой системы (помеченный в инспекторе как deprecated) то конфиг не откроется.
- Старые конфиги не будут работать в предпросмотре. Мы будем стремиться к тому, чтобы перенести все старые конфиги на новую систему.

# Изменения
- Реализация #307 
- Новые хандлеры событий в редакторе (при регистрации объекта в сцене и его удаления)
- Событие вставки теперь принимает параметр: массив вставленных объектов
- Исправлена горячая перезагрузка в редакторе при открытых дисплеях