### PR TITLE
Тестовое исправление синхронизации анимаций

### DIFF
--- a/Src/host/GameObjects/Mobs/BasicMob.sqf
+++ b/Src/host/GameObjects/Mobs/BasicMob.sqf
@@ -1507,6 +1507,11 @@ region(Animator)
 	_anim = {
 		(_this select 0) switchmove (_this select 1)
 	}; rpcAdd("switchMove",_anim);
+	
+	_anim = {
+		(_this select 0) switchmove (_this select 1);
+		(_this select 0) playMoveNow (_this select 1); //fix force switchmove for fuckedup animations configs
+	}; rpcAdd("switchMove_force",_anim);
 
 	_anim = {
 		(_this select 0) switchmove (_this select 1)


### PR DESCRIPTION
# Описание
Тестовое исправление синхронизации анимации. На ближайших играх перед раундом включаем флаг `debug_responeAnimationStatus = true` через дискорд для определения проблемной зоны синхронизации анимаций.