### PR TITLE
fix antag/role player priority

### DIFF
--- a/Src/host/Client/client.sqf
+++ b/Src/host/Client/client.sqf
@@ -770,7 +770,14 @@ class(ServerClient) /*extends(NetObject)*/
 	func(getPriorityForRoles)
 	{
 		objParams();
-		getSelf(access)
+		private _status = getSelf(access);
+		if (_status >= (["ACCESS_FORSAKEN"] call cm_accessTypeToNum)) then {
+			//Игрок >= форсекена то приоритет на роли/антаг
+			10
+		} else {
+			//Если меньше форсекена то приоритет 0
+			0
+		};
 	};
 
 	//очистка последней проверки забаненных ролей


### PR DESCRIPTION
# Описание
Во время ковыряния кода и ознакомление с синтаксисом взял #384 и попробовал исправить
Заодно пару вопросов по контексту задания

# Вопросы
- Как это протестировать? Как поставить User'у access ниже? По умолчанию вроде owner
- Это и подразумевалось в issue? Немного изучил структуру RoundManager куда мы тянем это значение - надо ли менять то как мы шаффлим массивы?
- Просто интересна деталь - зачем мы рандомим float от 0 до 1 когда начинаем считать приоритет на строке 462 в файле `Gamemode_RoundManager`
```
	{
		_prior = rand(0,1); //строки из-за хэшкарт

		//Эти данные управляют типом структуры. Сюда можно впихнуть выпавшее значение
		#define additionalData [_x,_prior]

		//готовый клиент
		if (getVar(_x,isReady)) then {

			//Предварительно накинуть приоритет клиенту...
			modvar(_prior) + callFunc(_x,getPriorityForRoles);

			_prior = str _prior;
			
			...
```