### PR TITLE
fix(Ashtray): увеличены слоты до 20, добавлен фильтр предметов

### DIFF
--- a/Src/host/GameObjects/Items/ReagentContainers/Kitchen.sqf
+++ b/Src/host/GameObjects/Items/ReagentContainers/Kitchen.sqf
@@ -231,9 +231,10 @@ class(Ashtray) extends(Container)
 	var(model,"ml_shabut\exodus\ashtray.p3d");
 	var(material,"MatMetal");
 	var(weight,gramm(130));
-	var_exprval(countSlots,BASE_STORAGE_CAPACITY(1.4));
+	var(countSlots,20);
 	var(size,ITEM_SIZE_SMALL);
 	var(maxSize,ITEM_SIZE_SMALL);
+	getterconst_func(allowedItemClasses,["Sigarette" arg "Zvak"]);
 endclass
 
 // Cups


### PR DESCRIPTION
## Изменения
- `countSlots`: 3 → 20
- `allowedItemClasses`: только `Sigarette` и `Zvak` (включая наследников)

## Контекст
У пепельницы было слишком мало слотов (3). Теперь 20 слотов + ограничение на тип предметов (сигареты, окурки, валюта).

Closes #688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Улучшения**
  * Ёмкость хранилища пепельницы изменена с динамически вычисляемого значения на фиксированное значение в 20 ячеек.
  * Добавлено ограничение типов предметов: теперь в пепельнице разрешено хранить только сигареты и определённые похожие предметы.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->