### PR TITLE
feat(admin): add thoughts command for silent mind messages

### DIFF
--- a/Src/host/ClientManager/cmds/Admin.sqf
+++ b/Src/host/ClientManager/cmds/Admin.sqf
@@ -179,6 +179,62 @@ addCommandWithDescription("mindmes",ACCESS_ADMIN,"Совесть говорит.
 	callFuncParams(thisClient,ShowMessageBox,"Input" arg ["Сначала сообщение"] arg _h);
 };
 
+addCommandWithDescription("thoughts",ACCESS_ADMIN,"Мысли (как mind, без звука)")
+{
+
+	_h = {
+		if (_value == "") exitwith {
+			callSelfParams(localSay,"Пустое сообщение" arg "error");
+		};
+
+		_handler = {
+			private _success = false;
+			private _text = getSelf(__internal_thoughts_lastvalue);
+			setSelf(__internal_thoughts_lastvalue,null);
+			private _name = ifcheck(isTypeOf(this,ServerClient),getSelf(name),getVar(getSelf(client),name));
+
+			call {
+				private _cli = _value call cm_findClientByName;
+				if isNullReference(_cli) exitwith {};
+				if !callFunc(_cli,isInGame) exitwith {};
+				_act = getVar(_cli,actor) getvariable vec2("link",nullPtr);
+				if isNullReference(_act) exitwith {};
+				
+				private _m = format["<t size='1.3' color='#23E899' font='RobotoCondensed'>%1</t>",_text];
+				callFuncParams(_act,localSay,_m);
+				_success = true;
+
+				private _mStr = format["(from %1 to %2): %3",_name,getVar(_cli,name),_text];
+				["ADMIN_THOUGHTS: "+ _mStr] call adminLog;
+				["@everyone ADMIN_THOUGHTS: "+_mStr] call disc_adminlog_provider;
+			};
+			callSelf(CloseMessageBox);
+			callSelfParams(localSay,"Выполнено - " + ifcheck(_success,"да","нет") arg "system");
+		};
+		private _dat = ["Выберите кому отправить:"];
+		{
+			#ifndef EDITOR
+			if equals(_x,this) then {continue};
+			#endif
+
+			_m = getVar(_x,actor) getvariable vec2("link",nullPtr);
+			if !isNullReference(_m) then {
+				_dat pushback (format["%1|%2",
+					callFuncParams(gm_currentMode,getCreditsInfo,_m arg false),
+					getVar(_x,name)
+				]);
+			};
+		} foreach (call cm_getAllClientsInGame);
+		
+		if (count _dat == 1) exitWith {
+			callSelfParams(localSay,"Пустой список" arg "error");
+		};
+		setSelf(__internal_thoughts_lastvalue,_value);
+		callSelfParams(ShowMessageBox,"Listbox" arg _dat arg _handler);
+	};
+	callFuncParams(thisClient,ShowMessageBox,"Input" arg ["Сначала сообщение"] arg _h);
+};
+
 addCommandWithDescription("adminmes",ACCESS_ADMIN,"Админское сообщение человеку")
 {
 	_h = {


### PR DESCRIPTION
Closes #670

## Что сделано
Новая админ-команда `thoughts` (Мысли) — как `mindmes`, но без звука и префикса.

| | mindmes | thoughts |
|---|---|---|
| Размер | 1.6 | 1.3 |
| Цвет | #52eb34 | #23E899 |
| Звук | effects\tension5 | нет |
| Префикс | «Ваша совесть говорит:» | нет |
| Лог | ADMIN_CONS | ADMIN_THOUGHTS |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые функции**
  * Добавлена новая админ-команда "Мысли" для отправки приватных сообщений игроку с валидацией ввода, форматированием текста и логированием действий администратора.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->