### PR TITLE
fix: add missing desc to start screen

### DIFF
--- a/Src/host/GameModes/Saloon/SaloonRoles.sqf
+++ b/Src/host/GameModes/Saloon/SaloonRoles.sqf
@@ -455,7 +455,7 @@ class(RBanditMainSaloon) extends(BasicRoleSaloon)
 	{
 		objParams_2(_mob,_usr);
 		super();
-		private _mes = format["<t size='1.4' color='#FF7400' font='RobotoCondensed'>%1</t>",callFunc(getVar(gm_currentMode,task),getDesc)];
+		private _mes = format["<t size='1.4' color='#FF7400' font='Ringbear'>%1</t>",callFunc(getVar(gm_currentMode,task),getDesc)];
 		callFuncParams(_mob,addFirstJoinMessage,_mes);
 		modVar(gm_currentMode,countAliveBandits, + 1);
 		
@@ -685,7 +685,7 @@ class(RSBSComannderSaloon) extends(BasicRoleSaloon)
 	{
 		objParams_2(_mob,_usr);
 		super();
-		private _mes = "<t size='1.4' color='#F60018' font='RobotoCondensed'>Поступил вызов - бар Дыра. Собрать бойцов, снарядить их и выдвинуться на место.</t>";
+		private _mes = "<t size='1.4' color='#F60018' font='Ringbear'>Поступил вызов - бар Дыра. Собрать бойцов, снарядить их и выдвинуться на место.</t>";
 		callFuncParams(_mob,addFirstJoinMessage,_mes);
 		setVar(gm_currentMode,isSBSCommandirSpawned,true);
 		

--- a/Src/host/GameObjects/Mobs/Mob_Tasks.sqf
+++ b/Src/host/GameObjects/Mobs/Mob_Tasks.sqf
@@ -99,8 +99,7 @@ region(Memories)
 
 			// Описание: задачи + описание роли + воспоминания
 			private _descParts = [];
-			
-			// Описание роли (из initWelcome)
+
 			{
 				_descParts pushBack _x;
 			} foreach getSelf(__firstLoginMesPool);
@@ -110,9 +109,17 @@ region(Memories)
 				_descParts pushBack _mobDesc;
 			};
 
+			private _mpool = [];
+			{
+				_mpool pushBack _x;
+			} foreach getVar(_mem,messages);
+			if (count _mpool > 0) then {
+				_descParts pushBack ("<t color='#5A71A3' font='Ringbear'>" + (_mpool joinString (sbr + sbr)) + "</t>");
+			};
+
 			// Задачи
 			if (count getSelf(tasks) > 0) then {
-				private _tasksText = "";
+				private _tasksText = "Мои задачи:";
 				{
 					private _tpref = "";
 					if getVar(_x,customTaskInfo) then {
@@ -124,12 +131,12 @@ region(Memories)
 						modvar(_tasksText) + sbr + format["%1: %2",getVar(_x,name),callFuncParams(_x,getTaskDescription,this)];
 					};
 				} foreach getSelf(tasks);
-				if (_tasksText != "") then {
+				if (_tasksText != "Мои задачи:") then {
 					_descParts pushBack _tasksText;
 				};
 			};
 
-			private _descriptionText = _descParts joinString sbr;
+			private _descriptionText = _descParts joinString (sbr + sbr);
 
 			private _evcls = {
 				setSelf(__isFirstUnsleep,false);


### PR DESCRIPTION
This pull request updates the display of role and memory messages to use a consistent font and improves the formatting of the "Memories" section for mobs. The most important changes are grouped below:

**Font and Message Formatting Consistency:**

* Changed the font for role join messages in both `RBanditMainSaloon` and `RSBSComannderSaloon` from `'RobotoCondensed'` to `'Ringbear'` to ensure consistent appearance for important notifications. [[1]](diffhunk://#diff-f1d42924f15edc50f2ebf6701405e4652bb3f0adfc7afca14d1090c95981f836L458-R458) [[2]](diffhunk://#diff-f1d42924f15edc50f2ebf6701405e4652bb3f0adfc7afca14d1090c95981f836L688-R688)
* Updated memory messages in the "Memories" section to display using the `'Ringbear'` font and a specific color for better visual distinction.

**Improvements to Memory and Task Description Formatting:**

* Added logic to include messages from the mob's memory (`_mem.messages`) in the description, separated by line breaks and styled for clarity.
* Changed the task section to always start with "Мои задачи:" and only include the section if there are tasks, improving clarity and consistency.
* Adjusted the final description text to separate sections with double line breaks for improved readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Новые возможности и улучшения

* **Стиль и интерфейс**
  * Обновлено визуальное оформление приветственных сообщений при входе в игру.
  * Добавлена поддержка отображения дополнительного пула сообщений на экране начала раунда.
  * Улучшена раскладка описаний в интерфейсе с лучшим разделением секций.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->