### PR TITLE
Preserve original args for admin logs

### DIFF
--- a/Src/host/ClientManager/CommandsExec.sqf
+++ b/Src/host/ClientManager/CommandsExec.sqf
@@ -56,13 +56,15 @@ cm_processClientCommand = {
 		errorformat("cm::processClientCommand() - Command %1 is undefined (called on %2)",_command arg _owner);
 	};
 
+	private _cmdArgsOrig = _arguments; //copy args for correct log (if args overrides inside command code)
+
 	//now call command!
 	call (_scom select 2);
 
 	logformat("cm::processClientCommand() - Command %1 called!",_command);
 	
-	[format["cm::processClientCommand() - %1 called cmd '%2' with args: %3",getVar(_client,name),_command,_arguments]] call adminLog;
-	[format["cm::processClientCommand() - %1 called cmd '%2' with args: %3",getVar(_client,name),_command,_arguments]] call disc_adminlog_provider;
+	[format["cm::processClientCommand() - %1 called cmd '%2' with args: %3",getVar(_client,name),_command,_cmdArgsOrig]] call adminLog;
+	[format["cm::processClientCommand() - %1 called cmd '%2' with args: %3",getVar(_client,name),_command,_cmdArgsOrig]] call disc_adminlog_provider;
 };
 
 cm_commands_map = createHashMap;


### PR DESCRIPTION
Copy _arguments into a private _cmdArgsOrig before calling the command so logs reflect the original arguments even if the command modifies them. Update adminLog and disc_adminlog_provider calls to use _cmdArgsOrig instead of _arguments; no other behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Исправления ошибок

* Повышена точность логирования команд администратора: система теперь корректно записывает оригинальные параметры команд в журналы для надежного и полного аудита выполненных операций.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->