### PR TITLE
fix: 724-245 ticket fixes

### DIFF
--- a/Src/host/GameModes/Saloon/GM_Saloon.sqf
+++ b/Src/host/GameModes/Saloon/GM_Saloon.sqf
@@ -1009,6 +1009,7 @@ class(Saloon_Task_RoofV2) extends(Saloon_Task_BaseV2)
 	var(barmenClueText,"");
 	var(militiaBriefSent,false);
 	var(finishCode,0);
+	var(cageCountdown,-1);
 
 	func(onTaskInit)
 	{
@@ -1067,6 +1068,7 @@ class(Saloon_Task_RoofV2) extends(Saloon_Task_BaseV2)
 	func(getFinishDesc)
 	{
 		objParams_1(_result);
+		if (_result == 5) exitWith {"Ополченцы закрыли и Барника, и Пахана в клетках. В Злачнике затишье."};
 		if (_result == 1) exitWith {"Пахан пережил разборку. Барник погиб, и теперь весь Злачник будет жить по воле 'Руки'."};
 		if (_result == 2) exitWith {"Барник пережил разборку. Пахан погиб и его место освободилось - надолго ли?"};
 		if (_result == 3) exitWith {"Ополченцы закрыли Барника в клетке. Пахан выстоял и теперь весь Злачник будет жить по воле 'Руки'."};
@@ -1093,8 +1095,27 @@ class(Saloon_Task_RoofV2) extends(Saloon_Task_BaseV2)
 		if (_timeGatePassed && _barmenDead) exitWith {1};
 		if (_timeGatePassed && _banditMainDead) exitWith {2};
 
-		if (!isNullReference(_barmenMob) && {callFuncParams(gm_currentMode,isMobInSBSCageArea,_barmenMob)}) exitWith {3};
-		if (!isNullReference(_banditMainMob) && {callFuncParams(gm_currentMode,isMobInSBSCageArea,_banditMainMob)}) exitWith {4};
+		private _barmenInCage = !isNullReference(_barmenMob) && {callFuncParams(gm_currentMode,isMobInSBSCageArea,_barmenMob)} && {!getVar(_barmenMob,isDead)};
+		private _banditInCage = !isNullReference(_banditMainMob) && {callFuncParams(gm_currentMode,isMobInSBSCageArea,_banditMainMob)} && {!getVar(_banditMainMob,isDead)};
+
+		// Запускаем таймер когда хоть кто-то оказался в клетке
+		private _countdown = getSelf(cageCountdown);
+		if ((_barmenInCage || _banditInCage) && {_countdown < 0}) then {
+			setSelf(cageCountdown, 0);
+			_countdown = 0;
+		};
+		if (_countdown >= 0) then {
+			modSelf(cageCountdown, + 1);
+		};
+		// По истечении 30 сек - фиксируем кто в клетке на этот момент
+		if (getSelf(cageCountdown) >= 30) exitWith {
+			setSelf(cageCountdown, -1);
+			private _r = 0;
+			if (_barmenInCage && _banditInCage) then {_r = 5};
+			if (_barmenInCage && !_banditInCage) then {_r = 3};
+			if (_banditInCage && !_barmenInCage) then {_r = 4};
+			_r
+		};
 
 		if (gm_roundDuration >= getVar(gm_currentMode,duration)) exitWith {-2};
 		0

--- a/Src/host/GameObjects/Items/Clothes/Masks.sqf
+++ b/Src/host/GameObjects/Items/Clothes/Masks.sqf
@@ -40,6 +40,9 @@ class(ItemMask) extends(Cloth)
 	//есть ли доступ ко рту
 	//todo переработать на dr covered FACE
 	getter_func(canAccessToMouth,false);
+
+	//скрывает ли маска личность (лицо) носителя при инспекте
+	getter_func(hideIdentity,true);
 	
 endclass
 
@@ -154,6 +157,7 @@ endclass
 class(DustGlasses) extends(ItemMask)
 	var(name,"Пылевые очки");
 	var(armaClass,"goggles_wastelandclothing03");
+	getter_func(hideIdentity,false);
 endclass
 
 class(RespiratorMaskTubes) extends(RespiratorMask)
@@ -171,6 +175,7 @@ class(SlaveCollar) extends(ItemMask)
 	var(name,"Рабский ошейник");
 	var(material,"MatMetal");
 	var(armaClass,"slavecollar_mask");
+	getter_func(hideIdentity,false);
 endclass
 
 class(FaceShieldSpartan) extends(ItemMask)

--- a/Src/host/GameObjects/Items/Lighting/Natural.sqf
+++ b/Src/host/GameObjects/Items/Lighting/Natural.sqf
@@ -302,7 +302,7 @@ class(Torch) extends(ILightible)
 
 		// --- Раны головы нельзя прижигать ------------------------------------
 		if (_bp == BP_INDEX_HEAD) exitWith {
-			callFuncParams(_usr,localSay,"Хорошая ли это идея?" arg "error");
+			callFuncParams(_usr,localSay,pick["Не получится прижечь рану на голове!" arg "На голове прижечь не получится." arg "Как ты на голове будешь ему прижигать!?" arg "Голову нельзя прижигать — слишком опасно." arg "Голову точно нельзя." arg "Прижечь рану на голове? Это его убьёт!"] arg "error");
 		};
 
 		// --- Определяем, есть ли что прижигать --------------------------------
@@ -398,10 +398,12 @@ class(Torch) extends(ILightible)
 		private _skillDelta = _skill - CAUT_SKILL_REFERENCE;
 
 		// --- Боль (применяется всегда, даже при провале) ---------------------
-		if callFunc(_targ,canFeelPain) then {
+		if (!callFunc(_targ,isDead) && {callFunc(_targ,canFeelPain)}) then {
 			callFuncParams(_targ,playEmoteSound,"agonyscream");
 		};
-		callFuncParams(_targ,addPainLevel,_bp arg CAUT_PAIN_LEVELS);
+		if (!callFunc(_targ,isDead)) then {
+			callFuncParams(_targ,addPainLevel,_bp arg CAUT_PAIN_LEVELS);
+		};
 
 		// --- Бросок на провал (низкий шанс, зависит от навыка) ---------------
 		private _failChance = CAUT_FAIL_BASE;
@@ -446,7 +448,6 @@ class(Torch) extends(ILightible)
 		_deathChance = (_deathChance max 0.01) min CAUT_DEATH_CAP;
 
 		if ((random 1) < _deathChance) exitWith {
-			callFuncParams(_targ,meSay,"умирает от болевого шока.");
 			callFuncParams(_targ,Die,di_partDamage);
 		};
 

--- a/Src/host/GameObjects/Items/Lighting/Natural.sqf
+++ b/Src/host/GameObjects/Items/Lighting/Natural.sqf
@@ -398,10 +398,10 @@ class(Torch) extends(ILightible)
 		private _skillDelta = _skill - CAUT_SKILL_REFERENCE;
 
 		// --- Боль (применяется всегда, даже при провале) ---------------------
-		if (!callFunc(_targ,isDead) && {callFunc(_targ,canFeelPain)}) then {
+		if (!getVar(_targ,isDead) && {callFunc(_targ,canFeelPain)}) then {
 			callFuncParams(_targ,playEmoteSound,"agonyscream");
 		};
-		if (!callFunc(_targ,isDead)) then {
+		if (!getVar(_targ,isDead)) then {
 			callFuncParams(_targ,addPainLevel,_bp arg CAUT_PAIN_LEVELS);
 		};
 

--- a/Src/host/GameObjects/Mobs/Mob.sqf
+++ b/Src/host/GameObjects/Mobs/Mob.sqf
@@ -422,7 +422,14 @@ region(Connect control events)
 			];
 		};
 
-		format[_rand + _postrand,callSelfParams(getNameEx,"кто")] + _commonInfo + _medMes;
+		private _displayName = callSelfParams(getNameEx,"кто");
+		if (!_isSelf && {!isTypeOf(_usr,MobObserver)} && {!callSelfParams(isEmptySlot,INV_FACE)}) then {
+			private _faceItem = callSelfParams(getItemInSlot,INV_FACE);
+			if (isTypeOf(_faceItem,ItemMask) && {callFunc(_faceItem,hideIdentity)}) then {
+				_displayName = ifcheck(getVar(getSelf(gender),пол) == "м","Незнакомец","Незнакомка");
+			};
+		};
+		format[_rand + _postrand,_displayName] + _commonInfo + _medMes;
 	};
 	
 	func(mindSay)

--- a/Src/host/GameObjects/Mobs/Mob.sqf
+++ b/Src/host/GameObjects/Mobs/Mob.sqf
@@ -426,7 +426,7 @@ region(Connect control events)
 		if (!_isSelf && {!isTypeOf(_usr,MobObserver)} && {!callSelfParams(isEmptySlot,INV_FACE)}) then {
 			private _faceItem = callSelfParams(getItemInSlot,INV_FACE);
 			if (isTypeOf(_faceItem,ItemMask) && {callFunc(_faceItem,hideIdentity)}) then {
-				_displayName = ifcheck(getVar(getSelf(gender),пол) == "м","Незнакомец","Незнакомка");
+				_displayName = ifcheck(callSelf(isMale),"Незнакомец","Незнакомка");
 			};
 		};
 		format[_rand + _postrand,_displayName] + _commonInfo + _medMes;


### PR DESCRIPTION
# Описание
Исправления для https://github.com/Relicta-Team/ReSDK_A3.vr/issues/724 и https://github.com/Relicta-Team/ReSDK_A3.vr/issues/245. Маска теперь скрывает имя персонажа

# Изменения
- маска которая скрывает лицо персонажа или его часть теперь блокирует показ имени при инспекте.
- убрана мета надпись о болевом шоке при прижигании
- мертвый не может кричать когда его успешно прижигают
- изменены сообщение о попытке прижигания головы на корректные
- в задаче "крыша" на злачнике теперь раунд завершается после короткого таймера при посадке в клетку барника/пахана вместо мгновенного завершения


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Заметки о выпуске

* **New Features**
  * Маски теперь по умолчанию скрывают личность — вместо имени отображается «Незнакомец/Незнакомка».
  * Отдельные предметы (очки, ошейник) явно не скрывают личность.
  * Прижигание ран показывает более подробные сообщения об ошибках.

* **Bug Fixes**
  * Исправлено применение боли/эмоций при прижигании для мертвых целей.
  * Добавлена 30-секундная задержка перед завершением салунной задачи при помещении целей в клетки.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->